### PR TITLE
Allow propagating inputs through JSON

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/githubaction/it/CommandsActionTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/githubaction/it/CommandsActionTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.githubaction.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.inject.Alternative;
@@ -43,12 +44,7 @@ public class CommandsActionTest {
 
         @Override
         public Inputs createInputs() {
-            return new DefaultTestInputs() {
-                @Override
-                public String getAction() {
-                    return CommandsAction.ACTION_NAME;
-                }
-            };
+            return new DefaultTestInputs(Map.of(Inputs.ACTION, CommandsAction.ACTION_NAME));
         }
     }
 }

--- a/integration-tests/src/test/java/io/quarkiverse/githubaction/it/ConfigFileActionTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/githubaction/it/ConfigFileActionTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.githubaction.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -47,12 +48,7 @@ public class ConfigFileActionTest {
 
         @Override
         public Inputs createInputs() {
-            return new DefaultTestInputs() {
-                @Override
-                public String getAction() {
-                    return ConfigFileAction.ACTION_NAME;
-                }
-            };
+            return new DefaultTestInputs(Map.of(Inputs.ACTION, ConfigFileAction.ACTION_NAME));
         }
     }
 

--- a/integration-tests/src/test/java/io/quarkiverse/githubaction/it/InputsContextInjectionActionTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/githubaction/it/InputsContextInjectionActionTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.githubaction.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.inject.Alternative;
@@ -47,12 +48,7 @@ public class InputsContextInjectionActionTest {
 
         @Override
         public Inputs createInputs() {
-            return new DefaultTestInputs() {
-                @Override
-                public String getAction() {
-                    return InputsContextInjectionAction.ACTION_NAME;
-                }
-            };
+            return new DefaultTestInputs(Map.of(Inputs.ACTION, InputsContextInjectionAction.ACTION_NAME));
         }
     }
 

--- a/integration-tests/src/test/java/io/quarkiverse/githubaction/it/IssueCatchAllActionTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/githubaction/it/IssueCatchAllActionTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.githubaction.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.inject.Alternative;
@@ -48,12 +49,7 @@ public class IssueCatchAllActionTest {
 
         @Override
         public Inputs createInputs() {
-            return new DefaultTestInputs() {
-                @Override
-                public String getAction() {
-                    return IssueCatchAllAction.ACTION_NAME;
-                }
-            };
+            return new DefaultTestInputs(Map.of(Inputs.ACTION, IssueCatchAllAction.ACTION_NAME));
         }
     }
 

--- a/integration-tests/src/test/java/io/quarkiverse/githubaction/it/IssueOpenedActionTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/githubaction/it/IssueOpenedActionTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.githubaction.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.inject.Alternative;
@@ -48,12 +49,7 @@ public class IssueOpenedActionTest {
 
         @Override
         public Inputs createInputs() {
-            return new DefaultTestInputs() {
-                @Override
-                public String getAction() {
-                    return IssueOpenedAction.ACTION_NAME;
-                }
-            };
+            return new DefaultTestInputs(Map.of(Inputs.ACTION, IssueOpenedAction.ACTION_NAME));
         }
     }
 

--- a/integration-tests/src/test/java/io/quarkiverse/githubaction/it/OutputsActionTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/githubaction/it/OutputsActionTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.githubaction.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.inject.Alternative;
@@ -43,12 +44,7 @@ public class OutputsActionTest {
 
         @Override
         public Inputs createInputs() {
-            return new DefaultTestInputs() {
-                @Override
-                public String getAction() {
-                    return OutputsAction.ACTION_NAME;
-                }
-            };
+            return new DefaultTestInputs(Map.of(Inputs.ACTION, OutputsAction.ACTION_NAME));
         }
     }
 }

--- a/integration-tests/src/test/java/io/quarkiverse/githubaction/it/SimpleNamedActionTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/githubaction/it/SimpleNamedActionTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.githubaction.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.inject.Alternative;
@@ -43,12 +44,7 @@ public class SimpleNamedActionTest {
 
         @Override
         public Inputs createInputs() {
-            return new DefaultTestInputs() {
-                @Override
-                public String getAction() {
-                    return SimpleNamedAction.ACTION_NAME;
-                }
-            };
+            return new DefaultTestInputs(Map.of(Inputs.ACTION, SimpleNamedAction.ACTION_NAME));
         }
     }
 }

--- a/integration-tests/src/test/java/io/quarkiverse/githubaction/it/util/DefaultTestInputs.java
+++ b/integration-tests/src/test/java/io/quarkiverse/githubaction/it/util/DefaultTestInputs.java
@@ -1,23 +1,20 @@
 package io.quarkiverse.githubaction.it.util;
 
-import java.util.Optional;
+import java.util.Collections;
+import java.util.Map;
 
 import io.quarkiverse.githubaction.Inputs;
 
 public class DefaultTestInputs implements Inputs {
 
-    @Override
-    public String get(String key) {
-        return null;
+    private final Map<String, String> inputs;
+
+    public DefaultTestInputs(Map<String, String> inputs) {
+        this.inputs = Collections.unmodifiableMap(inputs);
     }
 
     @Override
-    public String getAction() {
-        return null;
-    }
-
-    @Override
-    public Optional<String> getGitHubToken() {
-        return Optional.empty();
+    public Map<String, String> all() {
+        return inputs;
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/githubaction/Inputs.java
+++ b/runtime/src/main/java/io/quarkiverse/githubaction/Inputs.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.githubaction;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -7,9 +8,34 @@ import java.util.Optional;
  */
 public interface Inputs {
 
-    String get(String key);
+    String ACTION = "action";
+    String GITHUB_TOKEN = "github-token";
 
-    String getAction();
+    Map<String, String> all();
 
-    Optional<String> getGitHubToken();
+    default String get(String key) {
+        return all().get(key);
+    }
+
+    default String getRequired(String key) {
+        String value = all().get(key);
+
+        if (value == null) {
+            throw new IllegalArgumentException("Input " + key + " is required and has not been provided");
+        }
+
+        return get(key);
+    }
+
+    default String getOrDefault(String key, String defaultValue) {
+        return all().getOrDefault(key, defaultValue);
+    }
+
+    default String getAction() {
+        return all().getOrDefault(ACTION, Action.UNNAMED);
+    }
+
+    default Optional<String> getGitHubToken() {
+        return Optional.ofNullable(all().get(GITHUB_TOKEN));
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/githubaction/runtime/InputsImpl.java
+++ b/runtime/src/main/java/io/quarkiverse/githubaction/runtime/InputsImpl.java
@@ -1,10 +1,15 @@
 package io.quarkiverse.githubaction.runtime;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.githubaction.Action;
 import io.quarkiverse.githubaction.Inputs;
@@ -12,28 +17,65 @@ import io.quarkiverse.githubaction.Inputs;
 class InputsImpl implements Inputs {
 
     private static final String INPUT_PREFIX = "INPUT_";
-    private static final String ACTION = "action";
-    private static final String GITHUB_TOKEN = "github-token";
+    private static final String JSON_INPUTS = "JSON_INPUTS";
 
-    private final Map<String, String> inputs = new HashMap<>();
+    private final Map<String, String> inputs;
 
-    InputsImpl() {
-        for (Entry<String, String> envEntry : System.getenv().entrySet()) {
-            if (!envEntry.getKey().startsWith(INPUT_PREFIX)) {
-                continue;
+    InputsImpl(ObjectMapper objectMapper) {
+        String jsonInputs = System.getenv(JSON_INPUTS);
+        final Map<String, String> tmpInputs;
+
+        if (jsonInputs != null && !jsonInputs.isBlank()) {
+            // when using a composite action, inputs are not propagated
+            // we propagate them as JSON
+            try {
+                tmpInputs = objectMapper.readValue(jsonInputs, new TypeReference<Map<String, String>>() {
+                });
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("Unable to parse JSON inputs to a map", e);
             }
+        } else {
+            // when using a Docker action, we can extract the inputs from the environment variables
+            tmpInputs = new HashMap<>();
 
-            inputs.put(envEntry.getKey().substring(INPUT_PREFIX.length()).toLowerCase(Locale.ROOT), envEntry.getValue());
+            for (Entry<String, String> envEntry : System.getenv().entrySet()) {
+                if (!envEntry.getKey().startsWith(INPUT_PREFIX)) {
+                    continue;
+                }
+
+                tmpInputs.put(envEntry.getKey().substring(INPUT_PREFIX.length()).toLowerCase(Locale.ROOT), envEntry.getValue());
+            }
         }
+
+        this.inputs = Collections.unmodifiableMap(tmpInputs);
+    }
+
+    @Override
+    public Map<String, String> all() {
+        return inputs;
     }
 
     @Override
     public String get(String key) {
+        return inputs.get(key);
+    }
+
+    @Override
+    public String getRequired(String key) {
         if (!inputs.containsKey(key)) {
-            throw new IllegalArgumentException(key + " is not a valid input");
+            throw new IllegalArgumentException("Input " + key + " is required and has not been provided");
         }
 
-        return inputs.get(key);
+        return get(key);
+    }
+
+    @Override
+    public String getOrDefault(String key, String defaultValue) {
+        if (!inputs.containsKey(key)) {
+            return defaultValue;
+        }
+
+        return get(key);
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/githubaction/runtime/InputsInitializerImpl.java
+++ b/runtime/src/main/java/io/quarkiverse/githubaction/runtime/InputsInitializerImpl.java
@@ -1,6 +1,9 @@
 package io.quarkiverse.githubaction.runtime;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.githubaction.Inputs;
 import io.quarkiverse.githubaction.InputsInitializer;
@@ -8,8 +11,11 @@ import io.quarkiverse.githubaction.InputsInitializer;
 @Singleton
 public class InputsInitializerImpl implements InputsInitializer {
 
+    @Inject
+    ObjectMapper objectMapper;
+
     @Override
     public Inputs createInputs() {
-        return new InputsImpl();
+        return new InputsImpl(objectMapper);
     }
 }


### PR DESCRIPTION
In composite actions, the inputs are not propagated. Thus we need to
find a way to propagate them and using JSON is the only way to propagate
all of them in one go and not have to declare all of them as environment
variable.