### PR TITLE
Install repository credentials without using setup-java

### DIFF
--- a/integration-tests/src/test/resources/__snapshots__/CodestartKotlinTest/testContent/action.yml
+++ b/integration-tests/src/test/resources/__snapshots__/CodestartKotlinTest/testContent/action.yml
@@ -7,19 +7,37 @@ inputs:
   action:
     description: 'Name of the action (if named)'
     required: false
+
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: temurin
+    - name: Inject quarkus-github-action repository credentials
+      shell: bash
+      run: |
+        if [ -f ~/.m2/settings.xml ]; then
+          if ! grep -q '<id>quarkus-github-action</id>' ~/.m2/settings.xml; then
+            sed -i.bak 's@</servers>@<server><id>quarkus-github-action</id><username>${env.GITHUB_ACTOR}</username><password>${env.GITHUB_TOKEN}</password></server></servers>@' ~/.m2/settings.xml
+          fi
+        else
+          mkdir -p ~/.m2/
+          cat <<\EOF > ~/.m2/settings.xml
+        <?xml version="1.0"?>
+        <settings>
+          <servers>
+            <server>
+              <id>quarkus-github-action</id>
+              <username>${env.GITHUB_ACTOR}</username>
+              <password>${env.GITHUB_TOKEN}</password>
+            </server>
+          </servers>
+        </settings>
+        EOF
+        fi
     - name: Set up JBang
       uses: jbangdev/setup-jbang@main
     - name: Run the action
       id: action
-      run: jbang --java 11 --repos 'github=https://maven.pkg.github.com/your-org/your-repository/' --repos 'mavencentral' org.test:test-codestart:1.0.0-codestart
+      run: jbang --java 11 --repos 'quarkus-github-action=https://maven.pkg.github.com/your-org/your-repository/' --repos 'mavencentral' org.test:test-codestart:1.0.0-codestart
       shell: bash
       env:
         JSON_INPUTS: ${{ toJSON(inputs) }}

--- a/integration-tests/src/test/resources/__snapshots__/CodestartTest/testContent/action.yml
+++ b/integration-tests/src/test/resources/__snapshots__/CodestartTest/testContent/action.yml
@@ -7,19 +7,37 @@ inputs:
   action:
     description: 'Name of the action (if named)'
     required: false
+
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: temurin
+    - name: Inject quarkus-github-action repository credentials
+      shell: bash
+      run: |
+        if [ -f ~/.m2/settings.xml ]; then
+          if ! grep -q '<id>quarkus-github-action</id>' ~/.m2/settings.xml; then
+            sed -i.bak 's@</servers>@<server><id>quarkus-github-action</id><username>${env.GITHUB_ACTOR}</username><password>${env.GITHUB_TOKEN}</password></server></servers>@' ~/.m2/settings.xml
+          fi
+        else
+          mkdir -p ~/.m2/
+          cat <<\EOF > ~/.m2/settings.xml
+        <?xml version="1.0"?>
+        <settings>
+          <servers>
+            <server>
+              <id>quarkus-github-action</id>
+              <username>${env.GITHUB_ACTOR}</username>
+              <password>${env.GITHUB_TOKEN}</password>
+            </server>
+          </servers>
+        </settings>
+        EOF
+        fi
     - name: Set up JBang
       uses: jbangdev/setup-jbang@main
     - name: Run the action
       id: action
-      run: jbang --java 11 --repos 'github=https://maven.pkg.github.com/your-org/your-repository/' --repos 'mavencentral' org.test:test-codestart:1.0.0-codestart
+      run: jbang --java 11 --repos 'quarkus-github-action=https://maven.pkg.github.com/your-org/your-repository/' --repos 'mavencentral' org.test:test-codestart:1.0.0-codestart
       shell: bash
       env:
         JSON_INPUTS: ${{ toJSON(inputs) }}

--- a/runtime/src/main/codestarts/quarkus/quarkiverse-github-action-codestart/base/action.tpl.qute.yml
+++ b/runtime/src/main/codestarts/quarkus/quarkiverse-github-action-codestart/base/action.tpl.qute.yml
@@ -7,19 +7,37 @@ inputs:
   action:
     description: 'Name of the action (if named)'
     required: false
+
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: 21
-        distribution: temurin
+    - name: Inject quarkus-github-action repository credentials
+      shell: bash
+      run: |
+        if [ -f ~/.m2/settings.xml ]; then
+          if ! grep -q '<id>quarkus-github-action</id>' ~/.m2/settings.xml; then
+            sed -i.bak 's@</servers>@<server><id>quarkus-github-action</id><username>$\{env.GITHUB_ACTOR}</username><password>$\{env.GITHUB_TOKEN}</password></server></servers>@' ~/.m2/settings.xml
+          fi
+        else
+          mkdir -p ~/.m2/
+          cat <<\EOF > ~/.m2/settings.xml
+        <?xml version="1.0"?>
+        <settings>
+          <servers>
+            <server>
+              <id>quarkus-github-action</id>
+              <username>$\{env.GITHUB_ACTOR}</username>
+              <password>$\{env.GITHUB_TOKEN}</password>
+            </server>
+          </servers>
+        </settings>
+        EOF
+        fi
     - name: Set up JBang
       uses: jbangdev/setup-jbang@main
     - name: Run the action
       id: action
-      run: jbang --java {java.version} --repos 'github=https://maven.pkg.github.com/{github-repository}/' --repos 'mavencentral' {project.group-id}:{project.artifact-id}:{project.version}
+      run: jbang --java {java.version} --repos 'quarkus-github-action=https://maven.pkg.github.com/{github-repository}/' --repos 'mavencentral' {project.group-id}:{project.artifact-id}:{project.version}
       shell: bash
       env:
         JSON_INPUTS: ${{ toJSON(inputs) }}


### PR DESCRIPTION
Also use a specific repository called quarkus-github-action instead of the default github one, as the github one can have a different name depending on how you configure setup-java.

Fixes #218
Fixes #217