### PR TITLE
Allow injecting fully set up GHRepository into action method

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ on:
       - '*.adoc'
       - '*.txt'
       - '.all-contributorsrc'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -39,3 +40,6 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B formatter:validate clean install --file pom.xml -Dnative
+        env:
+          CURRENT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_REPO: ${{ github.repository }}

--- a/deployment/src/main/java/io/quarkiverse/githubaction/deployment/GitHubActionDotNames.java
+++ b/deployment/src/main/java/io/quarkiverse/githubaction/deployment/GitHubActionDotNames.java
@@ -3,6 +3,7 @@ package io.quarkiverse.githubaction.deployment;
 import java.util.Set;
 
 import org.jboss.jandex.DotName;
+import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
 import io.quarkiverse.githubaction.Action;
@@ -22,12 +23,14 @@ final class GitHubActionDotNames {
     static final DotName CONFIG_FILE = DotName.createSimple(ConfigFile.class.getName());
 
     static final DotName GITHUB = DotName.createSimple(GitHub.class.getName());
+    static final DotName REPOSITORY = DotName.createSimple(GHRepository.class.getName());
     static final DotName DYNAMIC_GRAPHQL_CLIENT = DotName.createSimple(DynamicGraphQLClient.class.getName());
     static final DotName CONTEXT = DotName.createSimple(Context.class.getName());
     static final DotName INPUTS = DotName.createSimple(Inputs.class.getName());
     static final DotName COMMANDS = DotName.createSimple(Commands.class.getName());
 
-    static final Set<DotName> INJECTABLE_TYPES = Set.of(GITHUB, DYNAMIC_GRAPHQL_CLIENT, CONTEXT, INPUTS, COMMANDS);
+    static final Set<DotName> INJECTABLE_TYPES = Set.of(
+            GITHUB, REPOSITORY, DYNAMIC_GRAPHQL_CLIENT, CONTEXT, INPUTS, COMMANDS);
 
     private GitHubActionDotNames() {
     }

--- a/docs/modules/ROOT/pages/developer-reference.adoc
+++ b/docs/modules/ROOT/pages/developer-reference.adoc
@@ -318,7 +318,7 @@ The following action method is executed any time an `issues` event is triggered
 [source,java]
 ----
     @Action
-    void test(@Issue GHEventPayload.Issue issuePayload) throws IOException {
+    void action(@Issue GHEventPayload.Issue issuePayload) throws IOException {
         GHIssue issue = issuePayload.getIssue();
 
         System.out.println("Repository: " + issue.getRepository().getFullName()); <1>
@@ -342,7 +342,7 @@ The following action method is executed when a new issue is opened:
 [source,java]
 ----
     @Action
-    void test(@Issue.Opened GHEventPayload.Issue issuePayload) {
+    void action(@Issue.Opened GHEventPayload.Issue issuePayload) {
         System.out.println("Repository: " + issuePayload.getIssue().getRepository().getFullName());
         System.out.println("Issue title: " + issuePayload.getIssue().getTitle());
     }
@@ -370,7 +370,7 @@ If the path is absolute, the file is searched from the root of the repository.
 [source,java]
 ----
     @Action
-    void test(@ConfigFile("example-config-file.yml") ConfigFileBean configFileBean) { <1>
+    void action(@ConfigFile("example-config-file.yml") ConfigFileBean configFileBean) { <1>
         System.out.println("Value 1: " + configFileBean.value1);
         System.out.println("Value 2: " + configFileBean.value2);
     }
@@ -383,6 +383,37 @@ If the path is absolute, the file is searched from the root of the repository.
     }
 ----
 <1> Read `.github/example-config-file.yml` from the default branch of the repository and inject the values into `ConfigFileBean` via Jackson deserialization.
+
+=== GHRepository
+
+You can inject the current repository into any action method. This allows you to access the REST API for https://docs.github.com/en/rest/repos[GitHub repositories].
+
+This enables you to e.g.:
+
+- create / query issues
+- create / query pull requests
+- access workflows
+- and much more
+
+[source,java]
+----
+@Action
+void action(GHRepository repository) { <1>
+    System.out.println(repository.getFullName());
+
+    var issueBuilder = repository.createIssue("Issue Name"); <2>
+    var pullRequest = repository.getPullRequest(42); <3>
+    var workflows = repository.listWorkflows(); <4>
+}
+
+----
+<1> Inject the current repository
+<2> Create an issue
+<3> Retreive a pull request
+<4> List all workflows
+
+
+For a complete list of all possibilities and the concrete syntax see the javadoc for https://github-api.kohsuke.org/apidocs/org/kohsuke/github/GHRepository.html[GHRepository].
 
 == Debugging
 

--- a/docs/modules/ROOT/pages/developer-reference.adoc
+++ b/docs/modules/ROOT/pages/developer-reference.adoc
@@ -409,11 +409,11 @@ void action(GHRepository repository) { <1>
 ----
 <1> Inject the current repository
 <2> Create an issue
-<3> Retreive a pull request
+<3> Retrieve a pull request
 <4> List all workflows
 
 
-For a complete list of all possibilities and the concrete syntax see the javadoc for https://github-api.kohsuke.org/apidocs/org/kohsuke/github/GHRepository.html[GHRepository].
+For a complete list of all possibilities and the concrete syntax see the Javadoc for https://github-api.kohsuke.org/apidocs/org/kohsuke/github/GHRepository.html[GHRepository].
 
 == Debugging
 

--- a/integration-tests/src/main/java/io/quarkiverse/githubaction/it/RepositoryAction.java
+++ b/integration-tests/src/main/java/io/quarkiverse/githubaction/it/RepositoryAction.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.githubaction.it;
+
+import org.kohsuke.github.GHRepository;
+
+import io.quarkiverse.githubaction.Action;
+
+public class RepositoryAction {
+    public static final String ACTION_NAME = "RepositoryAction";
+
+    @Action(ACTION_NAME)
+    void test(GHRepository repository) {
+        System.out.println(repository.getFullName());
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/githubaction/it/RepositoryActionTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/githubaction/it/RepositoryActionTest.java
@@ -1,0 +1,93 @@
+package io.quarkiverse.githubaction.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import io.quarkiverse.githubaction.Context;
+import io.quarkiverse.githubaction.ContextInitializer;
+import io.quarkiverse.githubaction.Inputs;
+import io.quarkiverse.githubaction.InputsInitializer;
+import io.quarkiverse.githubaction.it.RepositoryActionTest.RepositoryActionTestProfile;
+import io.quarkiverse.githubaction.testing.DefaultTestContext;
+import io.quarkiverse.githubaction.testing.DefaultTestInputs;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.main.Launch;
+import io.quarkus.test.junit.main.LaunchResult;
+import io.quarkus.test.junit.main.QuarkusMainTest;
+
+@QuarkusMainTest
+@TestProfile(RepositoryActionTestProfile.class)
+public class RepositoryActionTest {
+    private static final boolean LOCAL = System.getenv("CURRENT_REPO") == null;
+    private static final String REPOSITORY_NAME = LOCAL ? "my/local-repo" : System.getenv("CURRENT_REPO");
+    private static final String GITHUB_TOKEN = System.getenv("CURRENT_TOKEN");
+
+    @Test
+    @Launch(value = {})
+    @DisabledIf("isLocal")
+    public void shouldPrintRepositoryNameWhenRunningOnGitHub(LaunchResult result) {
+        assertThat(result.getOutput()).contains(REPOSITORY_NAME);
+    }
+
+    @Test
+    @Launch(value = {}, exitCode = 1)
+    @EnabledIf("isLocal")
+    public void shouldFailWhenRunningLocally(LaunchResult result) {
+        assertThat(result.getErrorOutput()).contains(REPOSITORY_NAME);
+    }
+
+    public static class RepositoryActionTestProfile implements QuarkusTestProfile {
+        @Override
+        public Set<Class<?>> getEnabledAlternatives() {
+            var alternatives = new HashSet<Class<?>>();
+            alternatives.add(MockInputsInitializer.class);
+            if (LOCAL) {
+                alternatives.add(MockContextInitializer.class);
+            }
+            return alternatives;
+        }
+    }
+
+    @Alternative
+    @Singleton
+    public static class MockInputsInitializer implements InputsInitializer {
+        @Override
+        public Inputs createInputs() {
+            var inputs = new HashMap<String, String>();
+            inputs.put(Inputs.ACTION, RepositoryAction.ACTION_NAME);
+            if (!LOCAL) {
+                inputs.put(Inputs.GITHUB_TOKEN, GITHUB_TOKEN);
+            }
+            return new DefaultTestInputs(inputs);
+        }
+    }
+
+    @Alternative
+    @Singleton
+    public static class MockContextInitializer implements ContextInitializer {
+        @Override
+        public Context createContext() {
+            return new DefaultTestContext() {
+                @Override
+                public String getGitHubRepository() {
+                    return REPOSITORY_NAME;
+                }
+            };
+        }
+    }
+
+    private static boolean isLocal() {
+        return LOCAL;
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/githubaction/it/RepositoryActionTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/githubaction/it/RepositoryActionTest.java
@@ -44,7 +44,9 @@ public class RepositoryActionTest {
     @Launch(value = {}, exitCode = 1)
     @EnabledIf("isLocal")
     public void shouldFailWhenRunningLocally(LaunchResult result) {
-        assertThat(result.getErrorOutput()).contains(REPOSITORY_NAME);
+        String fullOutput = result.getOutput() + "\n" + result.getErrorOutput();
+
+        assertThat(fullOutput).contains(REPOSITORY_NAME);
     }
 
     public static class RepositoryActionTestProfile implements QuarkusTestProfile {


### PR DESCRIPTION
Fixes #302

- See title
- Resolved access to deprecated apis in `GitHubActionProcessor.java`. The sole remaining deprecation warning will sort itself out, when the deprecated api is removed.
- The integration test will execute the real action, when running on GitHub. Locally the repository can't be injected due to the missing environment. 
- Documentation will follow